### PR TITLE
Fix grey transition blinking on BackgroundImg

### DIFF
--- a/src/components/Placeholder/PlaceholderBlurhash.tsx
+++ b/src/components/Placeholder/PlaceholderBlurhash.tsx
@@ -45,6 +45,7 @@ const PlaceholderBlurhash: React.FC<PlaceholderBlurhashProps> = (props) => {
       '.is-loaded': {
         opacity: 0,
         transition: 'opacity 0.3s ease-in-out 0s',
+        backgroundColor: 'transparent',
       },
     }),
   }

--- a/src/components/Placeholder/PlaceholderBlurhashWasm.tsx
+++ b/src/components/Placeholder/PlaceholderBlurhashWasm.tsx
@@ -51,6 +51,7 @@ const PlaceholderBlurhashWasm: React.FC<PlaceholderBlurhashWasmProps> = (props) 
       '.is-loaded': {
         opacity: 0,
         transition: 'opacity 0.3s ease-in-out 0s',
+        backgroundColor: 'transparent',
       },
     }),
   }

--- a/src/components/Placeholder/PlaceholderTinyBlur.tsx
+++ b/src/components/Placeholder/PlaceholderTinyBlur.tsx
@@ -49,6 +49,7 @@ const PlaceholderTinyBlur: React.FC<PlaceholderTinyBlurProps> = (props) => {
       '.is-loaded': {
         opacity: 0,
         transition: 'opacity 0.3s ease-in-out 0s',
+        backgroundColor: 'transparent',
       },
     }),
   }


### PR DESCRIPTION
When transitioning from placeholder to image, there should no longer be a grey intermediate state, before the final image is shown.