### PR TITLE
Add automatic backgroundSize inference to BackgroundImg

### DIFF
--- a/src/components/BackgroundImg/BackgroundImgBlurhash.tsx
+++ b/src/components/BackgroundImg/BackgroundImgBlurhash.tsx
@@ -65,7 +65,7 @@ const BackgroundImgBlurhash: React.FC<BackgroundImgBlurhashProps & ImgSizeTypePr
             className={clsx(classes?.placeholder)}
           />
           <ImageLoader key="IMAGE_LOADER" src={cloudimageUrl} onImageLoad={handleImageLoad} />
-          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
           <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
             {children}
           </BackgroundContent>
@@ -92,7 +92,7 @@ const BackgroundImgBlurhash: React.FC<BackgroundImgBlurhashProps & ImgSizeTypePr
           className={clsx(classes?.placeholder)}
         />
         <ImageLoader key="IMAGE_LOADER" src={cloudimageUrl} onImageLoad={handleImageLoad} />
-        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
         <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
           {children}
         </BackgroundContent>

--- a/src/components/BackgroundImg/BackgroundImgBlurhashWasm.tsx
+++ b/src/components/BackgroundImg/BackgroundImgBlurhashWasm.tsx
@@ -65,7 +65,7 @@ const BackgroundImgBlurhashWasm: React.FC<BackgroundImgBlurhashProps & ImgSizeTy
             className={clsx(classes?.placeholder)}
           />
           <ImageLoader key="IMAGE_LOADER" src={cloudimageUrl} onImageLoad={handleImageLoad} />
-          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
           <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
             {children}
           </BackgroundContent>
@@ -92,7 +92,7 @@ const BackgroundImgBlurhashWasm: React.FC<BackgroundImgBlurhashProps & ImgSizeTy
           className={clsx(classes?.placeholder)}
         />
         <ImageLoader key="IMAGE_LOADER" src={cloudimageUrl} onImageLoad={handleImageLoad} />
-        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
         <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
           {children}
         </BackgroundContent>

--- a/src/components/BackgroundImg/BackgroundImgPlain.tsx
+++ b/src/components/BackgroundImg/BackgroundImgPlain.tsx
@@ -39,7 +39,7 @@ const BackgroundImgPlain: React.FC<BackgroundImgPlainProps & ImgSizeTypeProps> =
         {...otherProps}
       >
         <LazyLoad once {...generateLazyLoadProps()}>
-          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
           <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
             {children}
           </BackgroundContent>
@@ -59,7 +59,7 @@ const BackgroundImgPlain: React.FC<BackgroundImgPlainProps & ImgSizeTypeProps> =
         onSizeUpdate={setComponentSize}
         {...otherProps}
       >
-        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
         <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
           {children}
         </BackgroundContent>

--- a/src/components/BackgroundImg/BackgroundImgTinyBlur.tsx
+++ b/src/components/BackgroundImg/BackgroundImgTinyBlur.tsx
@@ -52,7 +52,7 @@ const BackgroundImgTinyBlur: React.FC<BackgroundImgTinyBlurProps & ImgSizeTypePr
             className={clsx(classes?.placeholder)}
           />
           <ImageLoader key="IMAGE_LOADER" src={cloudimageUrl} onImageLoad={handleImageLoad} />
-          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+          <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
           <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
             {children}
           </BackgroundContent>
@@ -79,7 +79,7 @@ const BackgroundImgTinyBlur: React.FC<BackgroundImgTinyBlurProps & ImgSizeTypePr
           className={clsx(classes?.placeholder)}
         />
         <ImageLoader key="IMAGE_LOADER" src={cloudimageUrl} onImageLoad={handleImageLoad} />
-        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} />
+        <BackgroundImg key="IMAGE" src={cloudimageUrl} className={clsx(classes?.image)} operations={otherProps.operations} />
         <BackgroundContent key="CONTENT" className={clsx(classes?.content)}>
           {children}
         </BackgroundContent>

--- a/src/components/DisplayImage/BackgroundImg.tsx
+++ b/src/components/DisplayImage/BackgroundImg.tsx
@@ -5,10 +5,20 @@ import cxs from 'cxs'
 import clsx from 'clsx'
 
 // Types
+import { CloudimageFunc } from 'types'
 import { BackgroundImgProps } from './types'
 
 const BackgroundImg: React.FC<BackgroundImgProps> = (props) => {
-  const { src, classes, children, className } = props
+  const { src, classes, children, operations, className } = props
+
+  let backgroundSize: string | undefined
+  if (operations?.func == null || operations?.func === CloudimageFunc.Bound || operations?.func === CloudimageFunc.Cover || operations?.func === CloudimageFunc.Fit) {
+    backgroundSize = 'contain'
+  } else if (operations?.func === CloudimageFunc.Crop || operations?.func === CloudimageFunc.Face) {
+    backgroundSize = 'cover'
+  } else {
+    backgroundSize = 'cover'
+  }
 
   const css = {
     image: cxs({
@@ -21,7 +31,7 @@ const BackgroundImg: React.FC<BackgroundImgProps> = (props) => {
       width: '100%',
       height: '100%',
       backgroundImage: `url("${src}")`,
-      backgroundSize: 'cover',
+      backgroundSize: backgroundSize,
       backgroundPosition: 'center',
       backgroundRepeat: 'none',
     }),

--- a/src/components/DisplayImage/types.ts
+++ b/src/components/DisplayImage/types.ts
@@ -1,7 +1,10 @@
+import { CloudimageOperations } from '../../types/cloudimageOperations'
+
 export interface BackgroundImgProps {
   src?: string
   classes?: DisplayImageClasses
   className?: string
+  operations?: CloudimageOperations
 }
 
 export interface ImgProps {

--- a/src/types/cloudimageOperations.ts
+++ b/src/types/cloudimageOperations.ts
@@ -35,6 +35,12 @@ export enum CloudimageFunc {
    */
   Crop = 'crop',
   /**
+   * crops the image automatically keeping the most prominent face.
+   *
+   * Similar to CSS: `background-size: cover;`
+   */
+  Face = 'face',
+  /**
    * Resizes the image keeping proportions adding padding to satisfy the desired dimensions.
    *
    * Similar to CSS: `object-fit: contain;`


### PR DESCRIPTION
Not the `<BackgroundImg />` component will try to automatically infer the `backgroundSize` css value, from the providede CloudImg `func` parameter.